### PR TITLE
Upgrade native-build-tools version to 0.9.10

### DIFF
--- a/generators/server/generator.mjs
+++ b/generators/server/generator.mjs
@@ -79,7 +79,7 @@ export default class extends GeneratorBaseEntities {
           'native',
           `            <properties>
                 <repackage.classifier>exec</repackage.classifier>
-                <native-buildtools.version>0.9.9</native-buildtools.version>
+                <native-buildtools.version>0.9.10</native-buildtools.version>
             </properties>
             <dependencies>
                 <dependency>


### PR DESCRIPTION
This fixes "command is too long" on Windows. https://github.com/graalvm/setup-graalvm/issues/6#issuecomment-1054582083

Related: we might be able to change this line:

```js
if (process.env.GITHUB_ACTIONS) {
  buildArgs.push('--verbose', process.platform === 'darwin' ? '-J-Xmx13g' : '-J-Xmx7g');
}
```

to:

```js
if (process.env.GITHUB_ACTIONS) {
  buildArgs.push('--verbose', '-J-Xmx10g');
}
```

This works for me on macOS, Windows, and Linux. See [this build](https://github.com/oktadev/auth0-full-stack-java-example/runs/5366600107?check_suite_focus=true) for proof. You can see my [`pom.xml` setting too](https://github.com/oktadev/auth0-full-stack-java-example/blob/spring-native/pom.xml#L1341).