### PR TITLE
Upgrade to Spring Native v0.11.3

### DIFF
--- a/generators/server/generator.mjs
+++ b/generators/server/generator.mjs
@@ -66,7 +66,7 @@ export default class extends GeneratorBaseEntities {
         );
 
         this.addMavenProperty('repackage.classifier');
-        this.addMavenProperty('spring-native.version', '0.11.2');
+        this.addMavenProperty('spring-native.version', '0.11.3');
 
         this.addMavenDependency('org.springframework.experimental', 'spring-native', '${spring-native.version}');
         this.addMavenDependency('org.springdoc', 'springdoc-openapi-native', '1.6.6');


### PR DESCRIPTION
https://spring.io/blog/2022/03/01/spring-native-0-11-3-available-now

It says it supports Spring Boot 2.6.4, which JHipster [doesn't yet](https://github.com/jhipster/generator-jhipster/pull/17967). I'm testing locally to see if this is a problem. 