### PR TITLE
allow updates to production only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,5 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    ignore:
-      # generator-jhipster dependency is not fixed, it needs at least it's own yeoman-environment version.
-      # Don't update yeoman-environment and let generator-jhipster dependency version be dedupped.
-      - dependency-name: 'yeoman-environment'
+    allow:
+      - dependency-type: 'production'


### PR DESCRIPTION
Dependabot at this repository can take a lot of CI time with rebases and merges.
Dev dependencies can be updated at jhipster release cycle by regenerating package.json using generate-blueprint command.