### PR TITLE
Increase success GitHub actions

### DIFF
--- a/.github/workflows/jdl.yml
+++ b/.github/workflows/jdl.yml
@@ -108,7 +108,7 @@ jobs:
         uses: docker-practice/actions-setup-docker@5d9a5f65f510c01ec5f0bd81d5c95768b1ec032a
         # alternative solution https://github.com/actions/runner/issues/1456
         if: runner.os == 'macOS'
-        timeout-minutes: 15
+        timeout-minutes: 30
         with:
           docker_buildx: false
       - run: ls ~/Library/Caches/Homebrew/

--- a/.github/workflows/jdl.yml
+++ b/.github/workflows/jdl.yml
@@ -52,13 +52,11 @@ jobs:
             profile: dev
             e2e: 'false'
             jdl-extra-args: '--skip-install'
-            native-package-extra-args: '-DnativeBuildArgs=-J-Xmx10g'
           - os: windows-2022
             build-tool: gradle
             profile: dev
             e2e: 'false'
             jdl-extra-args: '--skip-install'
-            native-package-extra-args: '-DnativeBuildArgs=-J-Xmx10g'
     steps:
       #----------------------------------------------------------------------
       # Install all tools and check configuration
@@ -101,14 +99,6 @@ jobs:
         with:
           swap-size-gb: 10
 
-      - name:
-          'SETUP Windows: configure pagefile'
-          # v1.2 (7e234852c937eea04d6ee627c599fb24a5bfffee)
-        uses: al-cheb/configure-pagefile-action@7e234852c937eea04d6ee627c599fb24a5bfffee
-        if: runner.os == 'Windows'
-        with:
-          minimum-size: 10GB
-          maximum-size: 12GB
       - name: 'SETUP Windows: check pagefile'
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/jdl.yml
+++ b/.github/workflows/jdl.yml
@@ -38,15 +38,6 @@ jobs:
           - postgresql-mvc-jwt
           - postgresql-webflux-jwt
         include:
-          - os: ubuntu-20.04
-            build-tool: gradle
-            native-package-extra-args: '-DnativeBuildArgs=-J-Xmx10g'
-          - os: macos-11
-            build-tool: maven
-            native-package-extra-args: '-Dnative-build-args=-J-Xmx13g'
-          - os: macos-11
-            build-tool: gradle
-            native-package-extra-args: '-DnativeBuildArgs=-J-Xmx13g'
           - os: windows-2022
             build-tool: maven
             profile: dev
@@ -91,13 +82,6 @@ jobs:
       - name: 'SETUP: get date'
         id: get-date
         run: echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
-
-      - name: 'SETUP Linux: configure swap space'
-        if: runner.os == 'Linux'
-        # v1.0 (49819abfb41bd9b44fb781159c033dba90353a7c)
-        uses: pierotofy/set-swap-space@49819abfb41bd9b44fb781159c033dba90353a7c
-        with:
-          swap-size-gb: 10
 
       - name: 'SETUP Windows: check pagefile'
         if: runner.os == 'Windows'

--- a/.github/workflows/jdl.yml
+++ b/.github/workflows/jdl.yml
@@ -71,8 +71,10 @@ jobs:
         with:
           version: '22.3.3'
           java-version: '17'
+          distribution: 'graalvm-community'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: 'true'
       - name: 'SETUP: get date'
         id: get-date
         run: echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT

--- a/.github/workflows/jdl.yml
+++ b/.github/workflows/jdl.yml
@@ -84,8 +84,8 @@ jobs:
       - name: 'SETUP: setup graalvm'
         uses: graalvm/setup-graalvm@v1
         with:
-          version: '22.3.0'
-          java-version: '19'
+          version: '22.3.3'
+          java-version: '17'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: 'SETUP: get date'

--- a/.github/workflows/jdl.yml
+++ b/.github/workflows/jdl.yml
@@ -39,12 +39,6 @@ jobs:
           - postgresql-webflux-jwt
         include:
           - os: windows-2022
-            build-tool: maven
-            profile: dev
-            e2e: 'false'
-            jdl-extra-args: '--skip-install'
-          - os: windows-2022
-            build-tool: gradle
             profile: dev
             e2e: 'false'
             jdl-extra-args: '--skip-install'
@@ -83,11 +77,6 @@ jobs:
         id: get-date
         run: echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
 
-      - name: 'SETUP Windows: check pagefile'
-        if: runner.os == 'Windows'
-        run: |
-          (Get-CimInstance Win32_PageFileUsage).AllocatedBaseSize
-        shell: pwsh
       - name: 'SETUP Windows: force npm to use bash'
         if: runner.os == 'Windows'
         run: |


### PR DESCRIPTION
Resolves #57 (to some extent)

In previous CI builds, it appears we adjusted for limited memory in Github Actions by extending the page. However, particularly on Windows, there were issues where CI failed due to disk space exhaustion errors.

On the other hand, starting with GraalVM version 22.2, it's possible to build using less memory. Therefore, by addressing this memory shortage, the tests have become more stable, though not perfect. Currently, GC occurs occasionally, but it doesn't take an excessive amount of time. Builds are possible using roughly 5GB of memory.

Others:
- On the first run in Windows, the compiler crashes for 3 or 4 jobs. However, some of these can be passed by re-running.
   - I chose the GraalVM CE version because it has fewer errors compared to the Oracle version.
- `setup-graalvm` has been updated to match the [new scheme starting from GraalVM 22.0](https://github.com/graalvm/setup-graalvm).
- On macOS, there are frequent errors during Docker preparation, so I've extended the timeout duration.

