### PR TITLE
Add documentation for native build

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install -g generator-jhipster-native
 To build a native image, you need to install a JDK that is compatible with GraalVM. Please refer to the [GraalVM Release Notes](https://www.graalvm.org/release-notes/) and install the appropriate JDK. Using SDKMAN simplifies the installation process.
 
 ```
-sdk install java 20.0.2-graalce
+sdk install java 21-graalce
 ```
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install -g generator-jhipster-native
 To build a native image, you need to install a JDK that is compatible with GraalVM. Please refer to the [GraalVM Release Notes](https://www.graalvm.org/release-notes/) and install the appropriate JDK. Using SDKMAN simplifies the installation process.
 
 ```
-sdk install java 22.3.3.r17-grl
+sdk install java 20.0.2-graalce
 ```
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To install or update this blueprint:
 npm install -g generator-jhipster-native
 ```
 
-To build a Native image, you need to install a JDK that is compatible with GraalVM. Please refer to the [GraalVM Release Notes](https://www.graalvm.org/release-notes/) and install the appropriate JDK. Using SDKMAN simplifies the installation process.
+To build a native image, you need to install a JDK that is compatible with GraalVM. Please refer to the [GraalVM Release Notes](https://www.graalvm.org/release-notes/) and install the appropriate JDK. Using SDKMAN simplifies the installation process.
 
 ```
 sdk install java 22.3.3.r17-grl

--- a/README.md
+++ b/README.md
@@ -23,7 +23,15 @@ To install or update this blueprint:
 npm install -g generator-jhipster-native
 ```
 
+To build a Native image, you need to install a JDK that is compatible with GraalVM. Please refer to the [GraalVM Release Notes](https://www.graalvm.org/release-notes/) and install the appropriate JDK. Using SDKMAN simplifies the installation process.
+
+```
+sdk install java 22.3.3.r17-grl
+```
+
 # Usage
+
+## How to Generate Code
 
 To use this blueprint, run the below command
 
@@ -31,10 +39,40 @@ To use this blueprint, run the below command
 jhipster-native
 ```
 
+When building a new application, we recommend enabling e2e testing with Cypress to ensure that no runtime errors occur.
+
+```
+? Besides Jest/Vitest, which testing frameworks would you like to use? (Press <space> to select, <a> to
+ toggle all, <i> to invert selection, and <enter> to proceed)
+❯◉ Cypress
+```
+
 For available options, you can run
 
 ```bash
 jhipster-native app --help
+```
+
+## How to Build a Native Image
+
+To build a native image, execute the following command:
+
+```bash
+npm run native-package
+```
+
+After that, set up peripheral services like PostgreSQL using `npm run services:up` and ensure everything is ready.
+
+Lastly, run the Native image and experience its fast startup 😊.
+
+```bash
+npm run native-start
+```
+
+If you've enabled e2e testing with Cypress, you can verify its operation using the following command:
+
+```bash
+npm run native-e2e
 ```
 
 # Pre-release

--- a/generators/server/generator.js
+++ b/generators/server/generator.js
@@ -498,7 +498,7 @@ $2
 
 To build a Native image, you need to install a JDK that is compatible with GraalVM. Please refer to the [GraalVM Release Notes](https://www.graalvm.org/release-notes/) and install the appropriate JDK. Using SDKMAN simplifies the installation process.
 \`\`\`
-sdk install java 20.0.2-graalce
+sdk install java 21-graalce
 \`\`\`
 ### How to Build a Native Image
 

--- a/generators/server/generator.js
+++ b/generators/server/generator.js
@@ -479,6 +479,49 @@ class `,
           }
         }
       },
+
+      readme() {
+        this.editFile('README.md', content =>
+          content.includes('## About Native Build')
+            ? content
+            : content.replace(
+                /^(# .+?)(## .+)$/ms,
+                `$1
+The project has also been extended with [JHipster Native](https://github.com/jhipster/generator-jhipster-native) Blueprint.
+See what's been added here to learn [About Native Build](#about-native-build).
+
+$2
+
+## About Native Build
+
+### Installation
+
+To build a Native image, you need to install a JDK that is compatible with GraalVM. Please refer to the [GraalVM Release Notes](https://www.graalvm.org/release-notes/) and install the appropriate JDK. Using SDKMAN simplifies the installation process.
+\`\`\`
+sdk install java 20.0.2-graalce
+\`\`\`
+### How to Build a Native Image
+
+To build a native image, execute the following command:
+\`\`\`bash
+npm run native-package
+\`\`\`
+
+After that, set up peripheral services like PostgreSQL using \`npm run services:up\` and ensure everything is ready.
+
+Lastly, run the Native image and experience its fast startup 😊.
+\`\`\`bash
+npm run native-start
+\`\`\`
+
+If you've enabled e2e testing with Cypress, you can verify its operation using the following command:
+\`\`\`bash
+npm run native-e2e
+\`\`\`
+`,
+              ),
+        );
+      },
     });
   }
 


### PR DESCRIPTION
Resolves #58

- Added instructions for preparation, build, execution, and testing related to native builds in README.md.
- Updated the README.md in the generated project with similar instructions.
  - [see sample README.md](https://github.com/hide212131/jhipster-sample-app/blob/jhipster-native-add-readme/README.md)

Please let me know if there's anything you'd like to add or if any corrections to the English are needed