### PR TITLE
Add native test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ To build a native image, execute the following command:
 npm run native-package
 ```
 
+To build and run the JUnit test suite as a native image, execute the following command:
+
+```bash
+npm run native-test
+```
+
 After that, set up peripheral services like PostgreSQL using `npm run services:up` and ensure everything is ready.
 
 Lastly, run the Native image and experience its fast startup 😊.

--- a/generators/spring-boot/generator.js
+++ b/generators/spring-boot/generator.js
@@ -29,6 +29,14 @@ export default class extends BaseGenerator {
 
   get [BaseGenerator.PREPARING]() {
     return this.asPreparingTaskGroup({
+      nativeTestScript({ application }) {
+        const { buildToolGradle, packageJsonScripts, skipClient } = application;
+        const skipWebapp = skipClient ? '' : buildToolGradle ? ' -x webapp -x webapp_test' : ' -Dskip.installnodenpm -Dskip.npm';
+
+        packageJsonScripts['native-test'] = buildToolGradle
+          ? `./gradlew nativeTest -Pnative -Pdev${skipWebapp}`
+          : `./mvnw test -B -ntp -Pnative,nativeTest,dev${skipWebapp}`;
+      },
       fix({ application }) {
         application.languagesDefinition ??= undefined;
       },

--- a/generators/spring-boot/generator.spec.js
+++ b/generators/spring-boot/generator.spec.js
@@ -32,6 +32,15 @@ describe('SubGenerator spring-boot of native JHipster blueprint', () => {
       it('should succeed', () => {
         expect(result.getStateSnapshot()).toMatchSnapshot();
       });
+
+      it('should add a native test script', () => {
+        const expectedScript =
+          options.build === 'gradle'
+            ? '"native-test": "./gradlew nativeTest -Pnative -Pdev -x webapp -x webapp_test"'
+            : '"native-test": "./mvnw test -B -ntp -Pnative,nativeTest,dev -Dskip.installnodenpm -Dskip.npm"';
+
+        result.assertFileContent('package.json', expectedScript);
+      });
     });
   }
 });


### PR DESCRIPTION
Fix #41

This adds a generated `native-test` script so applications created with the native blueprint can run their JUnit suite through the GraalVM native test flow.

For Maven projects the script activates Spring Boot's `nativeTest` profile alongside the existing native blueprint profile. For Gradle projects it calls the `nativeTest` task with the same native/dev profile flags used by the rest of the blueprint.

I also added a generator assertion for both build tools and documented the new command in the README.

Validation:
- `npx prettier --check generators/spring-boot/generator.js generators/spring-boot/generator.spec.js README.md`
- `npx eslint generators/spring-boot/generator.js generators/spring-boot/generator.spec.js`
- `npx vitest run generators/spring-boot/generator.spec.js`