### PR TITLE
Add native test support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ To build a native image, execute the following command:
 npm run native-package
 ```
 
+To run the generated application tests in native mode, execute:
+
+```bash
+npm run native-test
+```
+
 After that, set up peripheral services like PostgreSQL using `npm run services:up` and ensure everything is ready.
 
 Lastly, run the Native image and experience its fast startup 😊.

--- a/generators/ci-cd/__snapshots__/generator.spec.js.snap
+++ b/generators/ci-cd/__snapshots__/generator.spec.js.snap
@@ -95,6 +95,8 @@ jobs:
           key: \${{ runner.os }}-npm-\${{ hashFiles('**/package-lock.json') }}
       - name: Install node.js packages
         run: npm install
+      - name: 'TEST: Native'
+        run: npm run native-test
       - name: 'E2E: Package'
         run: npm run native-package -- "-Dnative-build-args=\${{ matrix.native-build-args }}"
       - name: 'E2E: Prepare'

--- a/generators/ci-cd/templates/github-native.yml.ejs
+++ b/generators/ci-cd/templates/github-native.yml.ejs
@@ -112,6 +112,8 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
       - name: Install node.js packages
         run: npm install
+      - name: 'TEST: Native'
+        run: npm run native-test
       - name: 'E2E: Package'
         run: npm run native-package -- "-Dnative-build-args=${{ matrix.native-build-args }}"
 <%_ if (cypressTests) { _%>

--- a/generators/spring-boot/generator.js
+++ b/generators/spring-boot/generator.js
@@ -32,6 +32,14 @@ export default class extends BaseGenerator {
       fix({ application }) {
         application.languagesDefinition ??= undefined;
       },
+      nativeTestScript({ application }) {
+        const { buildToolGradle, packageJsonScripts } = application;
+
+        Object.assign(
+          packageJsonScripts,
+          buildToolGradle ? { 'native-test': './gradlew nativeTest -Pnative' } : { 'native-test': './mvnw test -B -ntp -Pnative' },
+        );
+      },
     });
   }
 

--- a/generators/spring-boot/generator.spec.js
+++ b/generators/spring-boot/generator.spec.js
@@ -32,6 +32,12 @@ describe('SubGenerator spring-boot of native JHipster blueprint', () => {
       it('should succeed', () => {
         expect(result.getStateSnapshot()).toMatchSnapshot();
       });
+
+      it('should add native test script', () => {
+        const expectedScript = options.build === 'gradle' ? './gradlew nativeTest -Pnative' : './mvnw test -B -ntp -Pnative';
+
+        result.assertFileContent('package.json', `"native-test": "${expectedScript}"`);
+      });
     });
   }
 });


### PR DESCRIPTION
Closes #41.

## Summary
- adds a generated `native-test` npm script for Maven and Gradle projects
- runs `npm run native-test` in the generated Native CI workflow before packaging/e2e
- documents the new native test command and covers the generated script with tests

## Verification
- `npm run vitest -- generators/spring-boot/generator.spec.js generators/ci-cd/generator.spec.js`

Note: the full `npm run vitest -- --update` also ran the relevant suites successfully, but the repository's `.blueprint/github-build-matrix/generator.spec.mjs` suite fails on Windows before our changes with an ESM absolute path loader error (`Received protocol 'c:'`).