### PR TITLE
Add native test support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ If you've enabled e2e testing with Cypress, you can verify its operation using t
 npm run native-e2e
 ```
 
+## How to Run Native Tests
+
+To build and execute the test suite as a native image, execute the following command:
+
+```bash
+npm run native-test
+```
+
 ## Native binary runtime errors
 
 GraalVM uses metadata to generate AOT compilation.

--- a/generators/ci-cd/__snapshots__/generator.spec.js.snap
+++ b/generators/ci-cd/__snapshots__/generator.spec.js.snap
@@ -95,6 +95,8 @@ jobs:
           key: \${{ runner.os }}-npm-\${{ hashFiles('**/package-lock.json') }}
       - name: Install node.js packages
         run: npm install
+      - name: 'TEST: Native'
+        run: npm run native-test
       - name: 'E2E: Package'
         run: npm run native-package -- "-Dnative-build-args=\${{ matrix.native-build-args }}"
       - name: 'E2E: Prepare'

--- a/generators/ci-cd/generator.spec.js
+++ b/generators/ci-cd/generator.spec.js
@@ -30,6 +30,18 @@ describe('SubGenerator ci-cd of native JHipster blueprint', () => {
       expect(result.getSnapshot('**/.github/workflows/native.yml')).toMatchSnapshot();
     });
 
+    it('native.yml should run native tests before native packaging', () => {
+      const snapshot = result.getSnapshot('**/.github/workflows/native.yml');
+      const nativeWorkflow = snapshot['.github/workflows/native.yml'].contents;
+      const nativeTestCommandIndex = nativeWorkflow.indexOf('run: npm run native-test');
+      const nativePackageCommandIndex = nativeWorkflow.indexOf('run: npm run native-package');
+
+      expect(nativeWorkflow).toContain("      - name: 'TEST: Native'");
+      expect(nativeTestCommandIndex).toBeGreaterThan(-1);
+      expect(nativePackageCommandIndex).toBeGreaterThan(-1);
+      expect(nativeTestCommandIndex).toBeLessThan(nativePackageCommandIndex);
+    });
+
     it('native-artifact.yml should match snapshot', () => {
       expect(result.getSnapshot('**/.github/workflows/native-artifact.yml')).toMatchSnapshot();
     });

--- a/generators/ci-cd/templates/github-native.yml.ejs
+++ b/generators/ci-cd/templates/github-native.yml.ejs
@@ -112,6 +112,8 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
       - name: Install node.js packages
         run: npm install
+      - name: 'TEST: Native'
+        run: npm run native-test
       - name: 'E2E: Package'
         run: npm run native-package -- "-Dnative-build-args=${{ matrix.native-build-args }}"
 <%_ if (cypressTests) { _%>

--- a/generators/spring-boot/generator.js
+++ b/generators/spring-boot/generator.js
@@ -32,6 +32,11 @@ export default class extends BaseGenerator {
       fix({ application }) {
         application.languagesDefinition ??= undefined;
       },
+      nativeTestScript({ application }) {
+        const { buildToolGradle, packageJsonScripts } = application;
+
+        packageJsonScripts['native-test'] = buildToolGradle ? './gradlew nativeTest -Pnative -Pdev' : './mvnw test -B -ntp -Pnative,dev';
+      },
     });
   }
 

--- a/generators/spring-boot/generator.spec.js
+++ b/generators/spring-boot/generator.spec.js
@@ -32,6 +32,14 @@ describe('SubGenerator spring-boot of native JHipster blueprint', () => {
       it('should succeed', () => {
         expect(result.getStateSnapshot()).toMatchSnapshot();
       });
+
+      it('should add a native test script', () => {
+        const snapshot = result.getSnapshot('**/package.json');
+        const packageJson = JSON.parse(snapshot['package.json'].contents);
+        const expectedScript = options.build === 'gradle' ? './gradlew nativeTest -Pnative -Pdev' : './mvnw test -B -ntp -Pnative,dev';
+
+        expect(packageJson.scripts['native-test']).toBe(expectedScript);
+      });
     });
   }
 });


### PR DESCRIPTION
Fixes #41.

## Summary
- add generated native-test scripts for Maven and Gradle applications
- run native tests in the Native CI workflow before native packaging
- document the native-test command and cover generated output with tests/snapshots

## Verification
- npm run ejslint
- npm test