### PR TITLE
Add native test support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ To build a native image, execute the following command:
 npm run native-package
 ```
 
+To run the generated application's tests as GraalVM native tests, execute:
+
+```bash
+npm run native-test
+```
+
 After that, set up peripheral services like PostgreSQL using `npm run services:up` and ensure everything is ready.
 
 Lastly, run the Native image and experience its fast startup 😊.

--- a/generators/ci-cd/__snapshots__/generator.spec.js.snap
+++ b/generators/ci-cd/__snapshots__/generator.spec.js.snap
@@ -95,6 +95,8 @@ jobs:
           key: \${{ runner.os }}-npm-\${{ hashFiles('**/package-lock.json') }}
       - name: Install node.js packages
         run: npm install
+      - name: 'TEST: Native'
+        run: npm run native-test
       - name: 'E2E: Package'
         run: npm run native-package -- "-Dnative-build-args=\${{ matrix.native-build-args }}"
       - name: 'E2E: Prepare'

--- a/generators/ci-cd/templates/github-native.yml.ejs
+++ b/generators/ci-cd/templates/github-native.yml.ejs
@@ -112,6 +112,8 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
       - name: Install node.js packages
         run: npm install
+      - name: 'TEST: Native'
+        run: npm run native-test
       - name: 'E2E: Package'
         run: npm run native-package -- "-Dnative-build-args=${{ matrix.native-build-args }}"
 <%_ if (cypressTests) { _%>

--- a/generators/spring-boot/generator.js
+++ b/generators/spring-boot/generator.js
@@ -32,6 +32,13 @@ export default class extends BaseGenerator {
       fix({ application }) {
         application.languagesDefinition ??= undefined;
       },
+      nativeTestScript({ application }) {
+        const { buildToolGradle, packageJsonScripts } = application;
+
+        Object.assign(packageJsonScripts, {
+          'native-test': buildToolGradle ? './gradlew nativeTest' : './mvnw -PnativeTest test -B -ntp',
+        });
+      },
     });
   }
 

--- a/generators/spring-boot/generator.spec.js
+++ b/generators/spring-boot/generator.spec.js
@@ -32,6 +32,12 @@ describe('SubGenerator spring-boot of native JHipster blueprint', () => {
       it('should succeed', () => {
         expect(result.getStateSnapshot()).toMatchSnapshot();
       });
+
+      it('should add native test script', () => {
+        const expectedScript = options.build === 'gradle' ? './gradlew nativeTest' : './mvnw -PnativeTest test -B -ntp';
+
+        result.assertFileContent('package.json', `"native-test": "${expectedScript}"`);
+      });
     });
   }
 });


### PR DESCRIPTION
## Summary

Adds generated native test support for the JHipster Native blueprint.

- adds a generated `native-test` npm script for both supported build tools
  - Gradle: `./gradlew nativeTest`
  - Maven: `./mvnw -PnativeTest test -B -ntp`
- runs `npm run native-test` in the generated Native CI workflow before packaging/e2e
- documents the new command in the README
- covers the generated scripts and workflow with existing generator tests/snapshots

## Bounty

Fixes #41

This targets the `$500` `$$ bug-bounty $$` issue. I noticed the existing open attempts, so this PR keeps the scope focused and uses the Spring Boot native test profile for Maven (`nativeTest`) rather than only the native packaging profile.

## Verification

- `npm run vitest -- generators/spring-boot/generator.spec.js generators/ci-cd/generator.spec.js --update`
- `npm run prettier-check`
- `npm run lint`
- `git diff --check`
- `npm test`
